### PR TITLE
Replace `for…each` loops with `for…of`

### DIFF
--- a/code/Admin/Admin.js
+++ b/code/Admin/Admin.js
@@ -272,7 +272,8 @@ Admin.purgeReferrers = function() {
 Admin.commitRequests = function() {
   var requests = app.data.requests;
   app.data.requests = {};
-  for each (var item in requests) {
+  for (let key in requests) {
+    let item = requests[key];
     switch (item.type) {
       case Story:
       var story = Story.getById(item.id);
@@ -292,7 +293,7 @@ Admin.commitEntries = function() {
   app.data.entries = [];
   var history = [];
 
-  for each (var item in entries) {
+  for (let item of entries) {
     var referrer = helma.Http.evalUrl(item.referrer);
     if (!referrer) {
       continue;

--- a/code/Api/Api.blogger.js
+++ b/code/Api/Api.blogger.js
@@ -115,7 +115,7 @@ Api.blogger.getRecentPosts = function(appKey, id, name, password, limit) {
   var result = [];
   var stories = res.handlers.membership.stories;
   var max = Math.min(stories.size(), Number(limit) || Infinity, 20);
-  for each (var story in stories.list(0, max)) {
+  for (let story of stories.list(0, max)) {
     result.push({
       postid: story._id,
       userid: story.creator.name,

--- a/code/Api/Api.metaWeblog.js
+++ b/code/Api/Api.metaWeblog.js
@@ -70,7 +70,7 @@ Api.metaWeblog.getRecentPosts = function(id, name, password, limit) {
   var result = [];
   var stories = res.handlers.membership.stories;
   var max = Math.min(stories.size(), Number(limit) || Infinity, 20);
-  for each (var story in stories.list(0, max)) {
+  for (let story of stories.list(0, max)) {
     result.push(Api.metaWeblog._getStruct(story));
   }
   return result;
@@ -182,7 +182,7 @@ Api.metaWeblog.getCategories = function(id, name, password) {
 
   var result = [];
   var tags = site.getTags('tags', Tags.ALL).list();
-  for each (var tag in tags) {
+  for (let tag of tags) {
     result.push({
       description: tag.name,
       htmlUrl: tag.href(),

--- a/code/Api/Api.mt.js
+++ b/code/Api/Api.mt.js
@@ -45,7 +45,7 @@ Api.mt.getRecentPostTitles = function(id, name, password, limit) {
   var result = [];
   var stories = res.handlers.membership.stories;
   var max = Math.min(stories.size(), Number(limit) || Infinity, 20);
-  for each (var story in stories.list(0, max)) {
+  for (let story of stories.list(0, max)) {
     result.push({
       postid: story._id,
       username: story.creator.name,
@@ -76,7 +76,7 @@ Api.mt.getCategoryList = function(id, name, password) {
 
   var result = [];
   var tags = site.getTags('tags', Tags.ALL).list();
-  for each (var tag in tags) {
+  for (let tag of tags) {
     result.push({
       categoryId: tag.name, // FIXME: tag._id,
       categoryName: tag.name
@@ -104,7 +104,7 @@ Api.mt.getPostCategories = function(id, name, password) {
   }
 
   var result = [];
-  for each (var tag in story.getTags()) {
+  for (let tag of story.getTags()) {
     result.push({
       categoryId: tag,
       categoryName: tag,

--- a/code/Archive/Archive.js
+++ b/code/Archive/Archive.js
@@ -175,7 +175,7 @@ Archive.prototype.stories_macro = function() {
     var site = res.handlers.site;
     var offset = (page - 1) * pageSize;
     var stories = site.stories.featured.list(offset, pageSize);
-    for each (var story in stories) {
+    for (let story of stories) {
       renderStory(story);
     };
     return;

--- a/code/Global/Global.js
+++ b/code/Global/Global.js
@@ -47,7 +47,7 @@ app.addRepository('modules/jala/code/Utilities.js');
 // Adding i18n message files as repositories
 (function() {
    var dir = new helma.File(app.dir, '../i18n');
-   for each (let fname in dir.list()) {
+   for (let fname of dir.list()) {
      fname.endsWith('.js') && app.addRepository(app.dir + '/../i18n/' + fname);
    }
 })();
@@ -768,7 +768,7 @@ function list_macro(param, id, limit) {
       break;
     }
   }
-  for each (var item in collection) {
+  for (let item of collection) {
     item && item.renderSkin(param.skin || skin);
   }
   return;
@@ -1307,7 +1307,7 @@ function getTimeZones(language) {
       locale = getLocale(language),
       ids = java.util.TimeZone.getAvailableIDs();
 
-  for each (let id in ids) {
+  for (let id of ids) {
     // Exclude confusing time zones
     if (id.length < 4 || !id.contains('/') ||
         id.startsWith('Etc') || id.startsWith('System')) {

--- a/code/Global/Sql.js
+++ b/code/Global/Sql.js
@@ -41,7 +41,7 @@ var Sql = function(options) {
     }
 
     this.next = function() {
-      for each (var key in columns) {
+      for (let key of columns) {
         this.values[key] = result.getColumnItem(key);
       }
       return;

--- a/code/Global/aspects.js
+++ b/code/Global/aspects.js
@@ -70,7 +70,7 @@ app.addRepository('modules/helma/Aspects.js');
   }
 
   var prototypes = app.__app__.getPrototypes().toArray();
-  for each (var prototype in prototypes) {
+  for (let prototype of prototypes) {
     if (prototype.name in global) {
       global[prototype.name].prototype.onCodeUpdate = function() {
         this.__renderSkin__ = this.renderSkin;

--- a/code/Global/i18n.js
+++ b/code/Global/i18n.js
@@ -41,7 +41,7 @@ Root.prototype.extractMessages = function(script, scanDirs, potFile) {
     return res.pop();
   }
   var args = ['-o', potFile, '-e', 'utf-8'];
-  for each (var dir in scanDirs.split(' ')) {
+  for (let dir of scanDirs.split(' ')) {
     args.push(app.dir + '/../' + dir);
   }
   var file = new helma.File(script);

--- a/code/Image/Image.js
+++ b/code/Image/Image.js
@@ -56,7 +56,7 @@ Image.add = function(data, parent, user) {
   user || (user = session.user);
   var image = new Image;
   if (data) {
-    for each (var key in Image.KEYS) {
+    for (let key of Image.KEYS) {
       image[key] = data[key];
     }
   }

--- a/code/Layout/Layout.js
+++ b/code/Layout/Layout.js
@@ -417,7 +417,7 @@ Layout.prototype.getArchive = function(skinPath) {
       /* Most likely the thumbnail file is identical to the image */
     }
     var image = new HopObject;
-    for each (var key in Image.KEYS) {
+    for (let key of Image.KEYS) {
       image[key] = this[key];
       data.images.add(image);
     }
@@ -507,7 +507,7 @@ Layout.prototype.values_macro = function() {
   this.renderSkin('$Layout#value', {'class': 'uk-hidden'});
 
   values.sort(new String.Sorter('key'));
-  for each (var pair in values) {
+  for (let pair of values) {
     var type = getType(pair.key);
     this.renderSkin('$Layout#value', {
       title: pair.key.capitalize(),

--- a/code/Poll/Poll.js
+++ b/code/Poll/Poll.js
@@ -187,7 +187,7 @@ Poll.prototype.status_action = function () {
  */
 Poll.prototype.update = function(data) {
   var choices = [];
-  for each (var title in data.title_array) {
+  for (let title of data.title_array) {
     if (title = title.trim()) {
       choices.push(title);
     }

--- a/code/Root/Root.js
+++ b/code/Root/Root.js
@@ -212,7 +212,7 @@ Root.prototype.updates_xml_action = function() {
   var entries = new java.util.ArrayList();
   var entry, description;
   var sites = root.updates.list(0, 25);
-  for each (var site in sites) {
+  for (let site of sites) {
     var story = site.stories.union.get(0);
     if (!story) {
       continue;
@@ -269,7 +269,7 @@ Root.prototype.health_action = function() {
     helma: Packages.helma.main.Server.getServer().version
   };
 
-  for each (key in ['activeThreads', 'freeThreads', 'requestCount',
+  for (let key of ['activeThreads', 'freeThreads', 'requestCount',
       'errorCount', 'xmlrpcCount', 'cacheusage']) {
     param[key] = formatNumber(app[key]);
   }

--- a/code/Site/Site.js
+++ b/code/Site/Site.js
@@ -607,7 +607,7 @@ Site.prototype.renderXml = function(collection) {
   var description;
   var list = collection.constructor === Array ? collection : collection.list(0, 25);
 
-  for each (var item in list) {
+  for (let item of list) {
     entry = new rome.SyndEntryImpl();
     entry.setTitle(item.title || formatDate(item.created, 'date'));
     entry.setLink(item.href());

--- a/code/Skin/Skin.js
+++ b/code/Skin/Skin.js
@@ -222,7 +222,7 @@ Skin.prototype.compare_action = function() {
   } else {
     res.push();
     var param = {}, leftLineNumber = rightLineNumber = 0;
-    for each (let line in diff) {
+    for (let line of diff) {
       if (line.deleted) {
         param.right = encode(line.value);
         param.leftStatus = 'added';

--- a/code/Skins/Skins.js
+++ b/code/Skins/Skins.js
@@ -128,7 +128,7 @@ Skins.prototype.all_action = function() {
     res.redirect(res.handlers.layout.skins.href(req.action));
   }
   res.push()
-  for each (let set in this.getListOfSkins()) {
+  for (let set of this.getListOfSkins()) {
     res.write(renderList(set[1], '$Skin#listItem'));
   }
   res.data.list = res.pop();
@@ -163,12 +163,12 @@ Skins.prototype.getSkin = function(group, name) {
 Skins.prototype.getListOfSkins = function() {
   var result = [];
   var options = Skin.getPrototypeOptions();
-  for each (var option in options) {
+  for (let option of options) {
     var skins = [];
     var prototype = option.value;
     var skinfiles = app.getSkinfilesInPath(res.skinpath);
     var skin = createSkin(skinfiles[prototype][prototype]);
-    for each (var name in skin.getSubskinNames()) {
+    for (let name of skin.getSubskinNames()) {
       var subskin = this.getSkin(prototype, name);
       skins.push(subskin);
     }

--- a/code/Tags/Tags.js
+++ b/code/Tags/Tags.js
@@ -143,7 +143,7 @@ Tags.prototype.list_macro = function(param, skin) {
   //var list = new jala.ListRenderer(collection);
   //list.render(skin || mgrlistitem);
   var index = start + 1;
-  for each (var item in collection) {
+  for (let item of collection) {
     // FIXME: Is there a more elegant solution?
     if (item.constructor !== Tag) {
       item = item.get(0);

--- a/compat/Layout/Layout.convert.js
+++ b/compat/Layout/Layout.convert.js
@@ -187,7 +187,7 @@ Layout.convert = function(fpath) {
 
   var convert2subskins = function(proto, dir) {
     res.push();
-    for each (var fname in dir.list()) {
+    for (let fname of dir.list()) {
       var file = new helma.File(dir, fname);
       var name = fname.split(".")[0], skin;
       if (skin = rename(proto, name)) {
@@ -238,7 +238,7 @@ Layout.convert = function(fpath) {
   }
 
   var dir = new helma.File(fpath, "images");
-  for each (var fname in dir.list()) {
+  for (let fname of dir.list()) {
     var file = new helma.File(dir, fname);
     file.move(new helma.File(fpath, fname));
   }
@@ -246,7 +246,7 @@ Layout.convert = function(fpath) {
   var inventory = new function() {
     var dir = new helma.File(fpath);
     var result = {};
-    for each (var fname in dir.list()) {
+    for (let fname of dir.list()) {
       var file = new helma.File(dir, fname);
       if (!file.isDirectory()) {
         // Where does the "image\" prefix come from in files from layouts.antville.org?
@@ -277,7 +277,7 @@ Layout.convert = function(fpath) {
   dir = new helma.File(fpath, "skins");
 
   var skin;
-  for each (var fname in dir.list()) {
+  for (let fname of dir.list()) {
     file = new helma.File(dir, fname);
     skin = convert2subskins(fname, file);
   }
@@ -286,7 +286,7 @@ Layout.convert = function(fpath) {
   data.images = new HopObject;
 
   var dir = new helma.File(fpath, "imagedata");
-  for each (fname in dir.list()) {
+  for (let fname of dir.list()) {
     if (fname.endsWith(".xml")) {
       file = new helma.File(dir, fname);
       data.images.add(convertImage(Xml.read(file)));

--- a/compat/Story/Story.js
+++ b/compat/Story/Story.js
@@ -104,7 +104,7 @@ Story.prototype.content_macro = function(param) {
   // Clone param and remove non-HTML attributes from param:
   var options = Object.clone.call(param, {});
   var noAttr = 'as clipping delimiter fallback limit part';
-  for each (let key in noAttr.split(String.SPACE)) {
+  for (let key of noAttr.split(String.SPACE)) {
     delete param[key];
   }
 

--- a/tools/updater/Global/Global.js
+++ b/tools/updater/Global/Global.js
@@ -49,7 +49,7 @@ var ResultWrapper = function(result) {
   }
 
   this.update = function() {
-    for each (var key in columns) {
+    for (let key of columns) {
       this.values[key] = result.getColumnItem(key);
     }
     return;
@@ -303,18 +303,18 @@ var execute = function(sql /*, value1, ..., valueN */) {
 
 var archive = function() {
   var staticDir = new helma.File(app.dir + "/../static");
-  for each (var siteName in staticDir.list()) {
+  for (let siteName of staticDir.list()) {
     var site = siteName !== "www" ? root.get(siteName) : root;
     if (!site) {
       continue;
     }
     var dir = new helma.File(staticDir, siteName + "/layouts");
-    for each (var layoutName in dir.list()) {
+    for (let layoutName of dir.list()) {
       if (layoutName.startsWith(".")) {
         continue;
       }
       var layout = new Layout(site);
-      for each (var image in dir.listRecursive(/\.(jpg|gif|png)$/)) {
+      for (let image of dir.listRecursive(/\.(jpg|gif|png)$/)) {
         var name = image.split("/").pop().split(".")[0];
         retrieve(query("archive", name, layoutName, siteName));
         traverse(function() {

--- a/tools/updater/Global/convert.js
+++ b/tools/updater/Global/convert.js
@@ -157,7 +157,7 @@ convert.layoutImages = function() {
 
     var fpath = antville().properties.staticPath;
     var files = [metadata.fileName, metadata.thumbnailName];
-    for each (var fname in files) {
+    for (let fname of files) {
       var source = new helma.File(fpath + "/layouts/" +
           this.parentLayout, fname);
       var layoutDir = new helma.File(fpath + this.SITE_ALIAS +
@@ -216,7 +216,7 @@ convert.sites = function() {
       metadata.locale += "_" + metadata.country;
     }
     var mode = metadata.usercontrib ? 'open' : this.mode;
-    for each (var key in ["enableping", "usercontrib", "archive",
+    for (let key of ["enableping", "usercontrib", "archive",
         "discussions", "days", "shortdateformat", "longdateformat",
         "linkcolor", "alinkcolor", "vlinkcolor", "smallcolor",
         "titlecolor", "titlefont", "textfont", "textcolor", "smallsize",
@@ -459,7 +459,7 @@ convert.skins = function() {
       }
       destination.makeDirectory();
       var files = source.list();
-      for each (var fname in files) {
+      for (let fname of files) {
         (new helma.File(source, fname)).hardCopy(new helma.File(destination, fname));
       }
     }
@@ -509,7 +509,7 @@ convert.skins = function() {
     appSkins[prototype] || (appSkins[prototype] = {});
     var skin = createSkin(skinfiles[prototype][prototype]);
     var subskins = skin.getSubskinNames();
-    for each (var name in subskins) {
+    for (let name of subskins) {
       appSkins[prototype][name] = skin.getSubskin(name).getSource();
     }
   }
@@ -608,7 +608,7 @@ convert.root = function() {
     }
     var dir = new helma.File(staticDir, this.name);
     var files = dir.list();
-    for each (fname in files) {
+    for (let fname of files) {
       var source = new helma.File(dir, fname);
       var dest = new helma.File(staticDir, "www/" + fname);
       log("Rename " + source + " to " + dest);

--- a/tools/updater/patch-20110301.js
+++ b/tools/updater/patch-20110301.js
@@ -19,7 +19,7 @@
 
 var sql = new Sql();
 var sql2 = new Sql();
-for each (let table in ["file", "image", "tag"]) {
+for (let table of ["file", "image", "tag"]) {
   sql.retrieve("select * from $0 where name like '%?%';", table);
   sql.traverse(function() {
     var name = "-".repeat(this.name.count("?"));


### PR DESCRIPTION
Rhino’s `for…each` loop is a non-standard JavaScript extension and causing some problems, e.g. with JSDoc.

Rewriting it is quite straight-forward, either by using the `for…of` loop, the `Array.forEach()` method, or the good old `for…in` syntax.

> 💡 Needs Helma with enabled ES6 features in Rhino (https://github.com/antville/helma/pull/68)